### PR TITLE
Fix Basic Auth for long username/passwords combinations

### DIFF
--- a/webunit/webunittest.py
+++ b/webunit/webunittest.py
@@ -85,7 +85,7 @@ class WebFetcher:
         '''Set the Basic authentication information to the given username
         and password.
         '''
-        self.authinfo = base64.encodestring('%s:%s'%(username,
+        self.authinfo = base64.b64encode('%s:%s'%(username,
             password)).strip()
 
     #


### PR DESCRIPTION
It was not possible to use Basic Auth with a long username/password combination because base64.encodestring would split the string with '\n' which generates invalid HTTP headers
